### PR TITLE
Move type definitions to separate file

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = function(config) {
     frameworks: ['mocha'],
 
     preprocessors: {
-      'lib/contacthub.js': ['webpack', 'sourcemap'],
+      'src/contacthub.js': ['webpack', 'sourcemap'],
       'test/contacthub.js': ['webpack', 'sourcemap']
     },
 
@@ -17,7 +17,7 @@ module.exports = function(config) {
 
     files: [
       'test/queue.js',
-      'lib/contacthub.js',
+      'src/contacthub.js',
       'test/contacthub.js'
     ],
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,111 @@
+// @flow
+
+type Config = (method: 'config', options: ConfigOptions) => void;
+type Customer = (method: 'customer', options: CustomerData) => void;
+type Event = (method: 'event', options: EventOptions) => void;
+
+export type ContactHubFunction = Config & Customer & Event;
+
+export type Auth = {
+  token: string,
+  workspaceId: string,
+  nodeId: string
+};
+
+export type ContactHubCookie = Auth & {
+  context: string,
+  sid: string,
+  customerId?: string,
+  hash?: string
+};
+
+export type ConfigOptions = {
+  token: string,
+  workspaceId: string,
+  nodeId: string,
+  context?: string
+};
+
+export type EventOptions = {
+  type: string,
+  properties?: Object
+};
+
+export type CustomerData = {
+  base: CustomerBase,
+  extended?: Object,
+  extra?: string,
+  tags?: CustomerTags,
+  externalId?: string
+};
+
+export type CustomerId = {
+  customerId: string
+};
+
+export type ExternalId = {
+  externalId: string
+};
+
+export type CustomerTags = {
+  auto?: Array<string>,
+  manual?: Array<string>
+};
+
+export type CustomerContacts = {
+  email?: string,
+  fax?: string,
+  mobilePhone?: string,
+  phone?: string,
+  otherContacts?: string,
+  mobileDevices?: string
+};
+
+export type CustomerGeo = {
+  lat: string,
+  lon: string
+};
+
+export type CustomerAddress = {
+  street?: string,
+  city?: string,
+  country?: string,
+  province?: string,
+  zip?: string,
+  geo?: CustomerGeo
+};
+
+export type CustomerCredential = {
+  username?: string,
+  password?: string
+};
+
+export type CustomerSocial = {
+  facebook?: string,
+  google?: string,
+  instagram?: string,
+  linkedin?: string,
+  qzone?: string,
+  twitter?: string
+};
+
+export type CustomerBase = {
+  pictureUrl?: string,
+  title?: string,
+  prefix?: string,
+  firstName?: string,
+  lastName?: string,
+  middleName?: string,
+  gender?: string,
+  dob?: string,
+  locale?: string,
+  timezone?: string,
+  contacts?: CustomerContacts,
+  address?: CustomerAddress,
+  credential: CustomerCredential,
+  educations?: string,
+  likes?: Number,
+  socialProfile: CustomerSocial,
+  jobs?: string,
+  subscriptions?: string
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "contacthub",
   "version": "0.2.0",
   "description": "Contacthub Tracking Script",
-  "main": "lib/contacthub.js",
+  "main": "src/contacthub.js",
   "scripts": {
     "test": "karma start --single-run",
     "test-watch": "karma start",

--- a/src/contacthub.js
+++ b/src/contacthub.js
@@ -5,115 +5,16 @@ import sha256 from 'jssha/src/sha256';
 import cookies from 'js-cookie';
 import { Promise } from 'es6-promise';
 
-type ContactHubFunction = Config & Customer & Event;
-
-type Config = (method: 'config', options: ConfigOptions) => void;
-type Customer = (method: 'customer', options: CustomerData) => void;
-type Event = (method: 'event', options: EventOptions) => void;
-
-type Auth = {
-  token: string,
-  workspaceId: string,
-  nodeId: string
-};
-
-type ContacthubCookie = Auth & {
-  sid: string,
-  context: string,
-  hash?: string,
-  customerId?: string
-};
-
-type ConfigOptions = {
-  token: string,
-  workspaceId: string,
-  nodeId: string,
-  context?: string
-};
-
-type EventOptions = {
-  type: string,
-  properties?: Object
-};
-
-type CustomerId = {
-  customerId: string
-};
-
-type ExternalId = {
-  externalId?: string
-};
-
-type CustomerTags = {
-  auto?: Array<string>,
-  manual?: Array<string>
-};
-
-type CustomerData = {
-  base: CustomerBase,
-  extended?: Object,
-  extra?: string,
-  tags?: CustomerTags,
-  externalId?: string
-};
-
-type CustomerContacts = {
-  email?: string,
-  fax?: string,
-  mobilePhone?: string,
-  phone?: string,
-  otherContacts?: string,
-  mobileDevices?: string
-};
-
-type CustomerAddress = {
-  street?: string,
-  city?: string,
-  country?: string,
-  province?: string,
-  zip?: string,
-  geo?: CustomerGeo
-};
-
-type CustomerGeo = {
-  lat: string,
-  lon: string
-};
-
-type CustomerCredential = {
-  username?: string,
-  password?: string
-};
-
-type CustomerSocial = {
-  facebook?: string,
-  google?: string,
-  instagram?: string,
-  linkedin?: string,
-  qzone?: string,
-  twitter?: string
-};
-
-type CustomerBase = {
-  pictureUrl?: string,
-  title?: string,
-  prefix?: string,
-  firstName?: string,
-  lastName?: string,
-  middleName?: string,
-  gender?: string,
-  dob?: string,
-  locale?: string,
-  timezone?: string,
-  contacts?: CustomerContacts,
-  address?: CustomerAddress,
-  credential: CustomerCredential,
-  educations?: string,
-  likes?: Number,
-  socialProfile: CustomerSocial,
-  jobs?: string,
-  subscriptions?: string
-};
+import type {
+  ContactHubFunction,
+  ContactHubCookie,
+  Auth,
+  ConfigOptions,
+  EventOptions,
+  CustomerData,
+  ExternalId,
+  CustomerId
+} from '../lib/types';
 
 xr.configure({
   promise: fn => new Promise(fn)
@@ -123,7 +24,7 @@ const apiUrl = 'https://api.contactlab.it/hub/v1';
 const cookieName = '_ch';
 const varName = 'ch';
 
-const getCookie = (): ContacthubCookie => {
+const getCookie = (): ContactHubCookie => {
   const cookie = cookies.getJSON(cookieName);
 
   if (!cookie) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  entry: './lib/contacthub.js',
+  entry: './src/contacthub.js',
   output: {
     path: './dist',
     filename: 'contacthub.js'


### PR DESCRIPTION
This keeps the main file shorter, and paves the way for sharing types between the Node SDK and the browser SDK.
