### PR TITLE
Only infer props if event type is "viewedPage"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contacthub",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Contacthub Tracking Script",
   "main": "src/contacthub.js",
   "scripts": {

--- a/src/contacthub.js
+++ b/src/contacthub.js
@@ -67,26 +67,30 @@ const config = (options: ConfigOptions): void => {
   cookies.set(cookieName, _ch);
 };
 
-const inferProperties = (customProperties?: Object): Object => {
-  const inferredProperties = {
-    title: document.title,
-    url: window.location.href,
-    path: window.location.pathname,
-    referrer: document.referrer
-  };
+const inferProperties = (type: string, customProperties?: Object): Object => {
+  if (type === 'viewedPage') {
+    const inferredProperties = {
+      title: document.title,
+      url: window.location.href,
+      path: window.location.pathname,
+      referrer: document.referrer
+    };
 
-  return Object.assign(inferredProperties, customProperties);
+    return Object.assign(inferredProperties, customProperties);
+  } else {
+    return Object.assign({}, customProperties);
+  }
 };
 
 const event = (options: EventOptions): void => {
   const { workspaceId, nodeId, token, context, sid, customerId } = getCookie();
   const { type, properties: customProperties } = options;
 
-  const properties = inferProperties(customProperties);
-
   if (!type) {
     throw new Error('Missing required event type');
   }
+
+  const properties = inferProperties(type, customProperties);
 
   const bringBackProperties = customerId ? undefined : {
     type: 'SESSION_ID',

--- a/test/event.js
+++ b/test/event.js
@@ -76,7 +76,7 @@ describe('Event API', () => {
     expect(JSON.parse(req.requestBody).customerId).to.eql('my-cid');
   });
 
-  it('infers common event properties', () => {
+  it('infers common "viewedPage" event properties', () => {
     document.title = 'Hello world';
     setConfig();
     _ch('event', { type: 'viewedPage' });
@@ -99,5 +99,18 @@ describe('Event API', () => {
 
     expect(props.title).to.eql('Custom title');
     expect(props.path).to.eql('/context.html');
+  });
+
+  it('does not infer properties on other event types', () => {
+    document.title = 'Hello world';
+    setConfig();
+    _ch('event', { type: 'something' });
+    const req = requests[0];
+    const props = JSON.parse(req.requestBody).properties;
+
+    expect(props.title).to.be.undefined;
+    expect(props.url).to.be.undefined;
+    expect(props.path).to.be.undefined;
+    expect(props.referrer).to.be.undefined;
   });
 });


### PR DESCRIPTION
This fixes the bug reported by @giuseppeguerrisi-clab where the props specific to the "viewedPage" event were attached to all types of events.

We don't infer any properties for other event types, but they could be easily added to the `inferProperties` method.
