### PR TITLE
#16: bringBackProperties behaviour (closes #16)

### DIFF
--- a/test/event.js
+++ b/test/event.js
@@ -76,6 +76,19 @@ describe('Event API', () => {
     expect(JSON.parse(req.requestBody).customerId).to.eql('my-cid');
   });
 
+  it('omits bringBackProperties when customerId is available', () => {
+    setConfig();
+    cookies.set(cookieName, Object.assign(getCookie(), {
+      customerId: 'my-cid'
+    }));
+    _ch('event', { type: 'viewedPage' });
+    const req = requests[0];
+    expect(req.url).to.equal(
+      `${apiUrl}/workspaces/${config.workspaceId}/events`
+    );
+    expect(JSON.parse(req.requestBody).bringBackProperties).to.be.undefined;
+  });
+
   it('infers common "viewedPage" event properties', () => {
     document.title = 'Hello world';
     setConfig();


### PR DESCRIPTION
Issue #16

This issue was reduced to only one new unit test. See the notes in #16 about why the other planned change was scrapped.

## Test Plan

### tests performed
* Unit tests passing
* Build passing

### tests not performed (domain coverage)
