### PR TITLE
#30: Allow using an existing customerId (closes #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ the following call:
 ch('customer', { id: clabId });
 ```
 
+An example use case is if you send a newsletter to your customers and you want
+to make sure that if they reach your website from a link contained in the email,
+they are immediately recognised even if they are not logged in.
+
+Please note that if a different user is logged in, the Contacthub id for the
+currently logged in user is stored in the Contacthub cookie. The id contained in
+the Contacthub cookie always takes precedence over an id specified using the
+`clabId` query string parameter.
 
 ## Contributing to this library
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ chub('event', { ... });
 <script async src='https://www.contactlab.com/contacthub.js'></script>
 ```
 
-
 #### Renaming the ContactHub cookie
 
 In the same way, you can set a custom name for the ContactHub cookie using:
@@ -184,6 +183,34 @@ For testing or debugging purposes, you might want to use a different API server:
 ```js
 window.ContactHubAPI = 'https://test-api/hub/v2';
 ```
+
+#### ContactHub ID
+
+Every Customer is assigned an id in ContactHub. In general, you don't have to
+think about it as the library will take care of it and avoid generating multiple
+IDs for the same Customer.
+
+If you store ContactHub ids on your database and you want to make sure that
+events sent via the library are associated to the same id, you can specify the
+ID when you use the `ch('customer', {...})` method:
+
+```js
+ch('customer', {
+  id: 'A_VALID_CONTACTHUB_ID',
+  ...other customer properties...
+});
+```
+
+#### The clabId query parameter
+
+You can also send a ContactHub id using the `clabId` parameter in the query
+string (`?clabId=A_VALID_CONTACTHUB_ID`). This is transformed by the library in
+the following call:
+
+```js
+ch('customer', { id: clabId });
+```
+
 
 ## Contributing to this library
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -102,6 +102,7 @@ export type CustomerBase = {
 };
 
 export type CustomerData = {
+  id?: string,
   base?: CustomerBase,
   extended?: Object,
   extra?: string,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run lint && npm run flow && npm run test && npm run webpack && npm run uglify",
     "lint": "eslint src && eslint test && eslint lib",
     "flow": "flow",
-    "example": "opn 'http://127.0.0.1.xip.io:8080/example/?workspaceId=WORKSPACE_ID&nodeId=NODE_ID&token=TOKEN' && http-server",
+    "example": "opn 'http://127.0.0.1:8080/example/?workspaceId=WORKSPACE_ID&nodeId=NODE_ID&token=TOKEN' && http-server",
     "package": "npm run build && zip -j dist/contacthub-$(git tag | tail -n 1).zip dist/*js",
     "webpack": "webpack",
     "uglify": "uglifyjs ./dist/contacthub.js --support-ie8 -c -m -o ./dist/contacthub.min.js"

--- a/src/contacthub.js
+++ b/src/contacthub.js
@@ -23,11 +23,11 @@ const varName: string = window.ContactHubObject || 'ch';
 const cookieName: string = window.ContactHubCookie || '_ch';
 const apiUrl: string = window.ContactHubAPI || 'https://api.contactlab.it/hub/v1';
 
-function getQueryParam(name) {
+const getQueryParam = (name) => {
   const match = RegExp(`[?&]${name}=([^&]*)`).exec(window.location.search);
   const val = match && decodeURIComponent(match[1].replace(/\+/g, ' '));
   return val || undefined;
-}
+};
 
 const newSessionId = (): string => uuid.v4();
 
@@ -43,46 +43,6 @@ const getCookie = (): ContactHubCookie => {
   }
 
   return cookie;
-};
-
-const allowedOptions = ['token', 'workspaceId', 'nodeId', 'context'];
-const config = (options: ConfigOptions): void => {
-  // get current ch cookie, if any
-  const _ch = cookies.getJSON(cookieName) || {};
-
-  // read Google Analytics query params if present
-  const utm_source = getQueryParam('utm_source');
-
-  if (utm_source) {
-    // Store ga values in the ch cookie, overwriting any previous ga value.
-    _ch.ga = {
-      utm_source,
-      utm_medium: getQueryParam('utm_medium'),
-      utm_term: getQueryParam('utm_term'),
-      utm_content: getQueryParam('utm_content'),
-      utm_campaign: getQueryParam('utm_campaign')
-    };
-  }
-
-  // generate sid if not already present
-  _ch.sid = _ch.sid || newSessionId();
-
-  // set all valid option params, keeping current value (if any)
-  const filteredOptions = Object.keys(options)
-    .filter(key => allowedOptions.indexOf(key) !== -1)
-    .reduce((obj, key) => {
-      obj[key] = options[key];
-      return obj;
-    }, {});
-  Object.assign(_ch, filteredOptions);
-
-  // default context to 'WEB', respecting cookie and options
-  if (!_ch.hasOwnProperty('context')) {
-    _ch.context = 'WEB';
-  }
-
-  // set updated cookie
-  cookies.set(cookieName, _ch, { expires: 365 });
 };
 
 const inferProperties = (type: string, customProperties?: Object): Object => {
@@ -285,6 +245,53 @@ const customer = (options: CustomerData): void => {
       .then(store)
       .then(reconcile);
 
+  }
+};
+
+const allowedOptions = ['token', 'workspaceId', 'nodeId', 'context'];
+const config = (options: ConfigOptions): void => {
+  // get current ch cookie, if any
+  const _ch = cookies.getJSON(cookieName) || {};
+
+  // read Google Analytics query params if present
+  const utm_source = getQueryParam('utm_source');
+
+  if (utm_source) {
+    // Store ga values in the ch cookie, overwriting any previous ga value.
+    _ch.ga = {
+      utm_source,
+      utm_medium: getQueryParam('utm_medium'),
+      utm_term: getQueryParam('utm_term'),
+      utm_content: getQueryParam('utm_content'),
+      utm_campaign: getQueryParam('utm_campaign')
+    };
+  }
+
+  // generate sid if not already present
+  _ch.sid = _ch.sid || newSessionId();
+
+  // set all valid option params, keeping current value (if any)
+  const filteredOptions = Object.keys(options)
+    .filter(key => allowedOptions.indexOf(key) !== -1)
+    .reduce((obj, key) => {
+      obj[key] = options[key];
+      return obj;
+    }, {});
+  Object.assign(_ch, filteredOptions);
+
+  // default context to 'WEB', respecting cookie and options
+  if (!_ch.hasOwnProperty('context')) {
+    _ch.context = 'WEB';
+  }
+
+  // set updated cookie
+  cookies.set(cookieName, _ch, { expires: 365 });
+
+  // support special query param clabId
+  const clabId = getQueryParam('clabId');
+
+  if (clabId) {
+    customer({ id: clabId });
   }
 };
 


### PR DESCRIPTION
Closes #30

## Test Plan

### tests performed
* added some new unit tests, no regression on the existing ones
* tested manually with `npm run example`

### tests not performed (domain coverage)
I have not tested all the possible edge cases (e.g. sending different IDs from the query string and the `customer` method). I expect this feature to be used by a minority of users, and it seems to work correctly for the scenario described in the requirements.