### PR TITLE
#32: contextInfo cannot be set (closes #32)

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -16,6 +16,7 @@ export type GoogleAnalytics = {|
 
 export type ContactHubCookie = Auth & {
   context: string,
+  contextInfo: Object,
   sid: string,
   customerId?: string,
   hash?: string,
@@ -26,7 +27,8 @@ export type ConfigOptions = {
   token: string,
   workspaceId: string,
   nodeId: string,
-  context?: string
+  context?: string,
+  contextInfo?: Object
 };
 
 export type EventOptions = {

--- a/src/contacthub.js
+++ b/src/contacthub.js
@@ -62,7 +62,7 @@ const inferProperties = (type: string, customProperties?: Object): Object => {
 
 const event = (options: EventOptions): void => {
   const {
-    workspaceId, nodeId, token, context, sid, customerId, ga
+    workspaceId, nodeId, token, context, contextInfo, sid, customerId, ga
   } = getCookie();
   const { type, properties: customProperties } = options;
 
@@ -86,6 +86,7 @@ const event = (options: EventOptions): void => {
     data: {
       type,
       context,
+      contextInfo,
       properties,
       tracking,
       customerId,
@@ -260,7 +261,9 @@ const customer = (options: CustomerData): void => {
   }
 };
 
-const allowedOptions = ['token', 'workspaceId', 'nodeId', 'context'];
+const allowedConfigOptions = [
+  'token', 'workspaceId', 'nodeId', 'context', 'contextInfo'
+];
 const config = (options: ConfigOptions): void => {
   // get current ch cookie, if any
   const _ch = cookies.getJSON(cookieName) || {};
@@ -284,17 +287,16 @@ const config = (options: ConfigOptions): void => {
 
   // set all valid option params, keeping current value (if any)
   const filteredOptions = Object.keys(options)
-    .filter(key => allowedOptions.indexOf(key) !== -1)
+    .filter(key => allowedConfigOptions.indexOf(key) !== -1)
     .reduce((obj, key) => {
       obj[key] = options[key];
       return obj;
     }, {});
   Object.assign(_ch, filteredOptions);
 
-  // default context to 'WEB', respecting cookie and options
-  if (!_ch.hasOwnProperty('context')) {
-    _ch.context = 'WEB';
-  }
+  // default values for context and contextInfo
+  _ch.context = _ch.context || 'WEB';
+  _ch.contextInfo = _ch.contextInfo || {};
 
   // set updated cookie
   cookies.set(cookieName, _ch, { expires: 365 });

--- a/test/config.js
+++ b/test/config.js
@@ -61,6 +61,19 @@ describe('Config API', () => {
     expect(getCookie().context).to.equal('foo');
   });
 
+  it('allows to specify optional contextInfo', () => {
+    _ch('config', {
+      workspaceId: 'workspace_id',
+      nodeId: 'node_id',
+      token: 'ABC123',
+      context: 'foo',
+      contextInfo: {
+        foo: 'bar'
+      }
+    });
+    expect(getCookie().contextInfo).to.eql({ foo: 'bar' });
+  });
+
   it('allows to override a single required param', () => {
     _ch('config', {
       nodeId: 'another_node'

--- a/test/event.js
+++ b/test/event.js
@@ -46,7 +46,7 @@ describe('Event API', () => {
     setConfig();
     _ch('event', { type: 'viewedPage' });
     const req = requests[0];
-    const res = JSON.parse(req.requestBody);
+    const reqBody = JSON.parse(req.requestBody);
 
     expect(req.url).to.equal(
       `${apiUrl}/workspaces/${config.workspaceId}/events`
@@ -54,9 +54,8 @@ describe('Event API', () => {
     expect(req.requestHeaders.Authorization).to.equal(
       `Bearer ${config.token}`
     );
-    expect(res.type).to.equal('viewedPage');
-    expect(res.context).to.equal('WEB');
-    expect(res.bringBackProperties).to.eql({
+    expect(reqBody.type).to.equal('viewedPage');
+    expect(reqBody.bringBackProperties).to.eql({
       type: 'SESSION_ID',
       value: getCookie().sid,
       nodeId: config.nodeId
@@ -125,5 +124,31 @@ describe('Event API', () => {
     expect(props.url).to.be.undefined;
     expect(props.path).to.be.undefined;
     expect(props.referer).to.be.undefined;
+  });
+
+  it('gets the "context" from the cookie', () => {
+    setConfig();
+    cookies.set(cookieName, Object.assign(getCookie(), {
+      context: 'FOO'
+    }));
+
+    _ch('event', { type: 'viewedPage' });
+    const req = requests[0];
+    const reqBody = JSON.parse(req.requestBody);
+
+    expect(reqBody.context).to.equal('FOO');
+  });
+
+  it('gets the "contextInfo" from the cookie', () => {
+    setConfig();
+    cookies.set(cookieName, Object.assign(getCookie(), {
+      contextInfo: { foo: 'bar' }
+    }));
+
+    _ch('event', { type: 'viewedPage' });
+    const req = requests[0];
+    const reqBody = JSON.parse(req.requestBody);
+
+    expect(reqBody.contextInfo).to.eql({ foo: 'bar' });
   });
 });


### PR DESCRIPTION
Closes #32

## Test Plan

### tests performed
* added new unit tests
* tested manually with this example value: `contextInfo: { client: { userAgent: 'foobar' } }`

### tests not performed (domain coverage)
