### PR TITLE
Handle aggregate nodes

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -23,8 +23,7 @@ if [ -z "$husky_skip_init" ]; then
 
   if [ $exitCode != 0 ]; then
     echo "husky - $hook_name hook exited with code $exitCode (error)"
-    exit $exitCode
   fi
 
-  exit 0
+  exit $exitCode
 fi

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ ch('config', {
   workspaceId: 'w_id', // required, found in the Customer Hub admin area
   nodeId: 'node_id', // required, found in the Customer Hub admin area
   token: 'UYTF546FUTF636JH', // required, found in the Customer Hub admin area
+  target: 'ENTRY', // optional, can be "ENTRY" or "AGGREGATE", defaults to "ENTRY"
   context: 'CTX', // optional, defaults to 'WEB'
-  contextInfo: {}, // optional, defaults to an empty object,
+  contextInfo: {}, // optional, defaults to an empty object
 });
 ```
 
@@ -219,7 +220,7 @@ ch('customer', {
 });
 ```
 
-#### The clabId query parameter
+#### The `clabId` query parameter
 
 You can also send a Customer Hub id using the `clabId` parameter in the query string (`?clabId=A_VALID_CONTACTHUB_ID`). This is transformed by the library in the following call:
 
@@ -229,8 +230,20 @@ ch('customer', {id: clabId});
 
 An example use case is if you send a newsletter to your customers and you want to make sure that if they reach your website from a link contained in the email, they are immediately recognised even if they are not logged in.
 
-Please note that if a different user is logged in, the Customer Hub id for the currently logged in user is stored in the Customer Hub cookie. The id contained in the Customer Hub cookie always takes precedence over an id specified using the
-`clabId` query string parameter.
+Please note that if a different user is logged in, the Customer Hub id for the currently logged in user is stored in the Customer Hub cookie. The id contained in the Customer Hub cookie always takes precedence over an id specified using the `clabId` query string parameter.
+
+#### Aggregate nodes
+
+The SDK can handle also [aggregate nodes](https://explore.contactlab.com/understanding-nodes-and-trees/?lang=en).
+
+In order to send data to this kind of nodes (instead of standard "entry" ones), you have to set these optional configuration properties:
+- `target` to `AGGREGATE`;
+- `aggregateNodeId` to the aggregate node's id (found in the Customer Hub admin area);
+- `aggregateToken` to the aggregate node's token (found in the Customer Hub admin area).
+
+Please be aware that customer's creation and updating **are bypassed** when `target` is `AGGREGATE`, but reconciliation and id conflict resolution keep executing.
+
+Just as `clabId` also the `target` property can be set using the `target` parameter in the query string (`?target=AGGREGATE`).
 
 ## Contributing to this library
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This also offers an advantage that if the visitor to your webpage has already do
 
 To load a hosted library, copy and paste the HTML snippet for that library (shown below) in your web page.
 
+**Warning! The SDK is published in [UMD](https://github.com/umdjs/umd) format: if you use non-standard ways to load scripts in page (like [RequireJS](https://requirejs.org/)), please refer to the corresponding documentation.**
+
 #### ES6 version minified
 
 ```html

--- a/docs/index.md
+++ b/docs/index.md
@@ -263,9 +263,19 @@ An example use case is if you send a newsletter to your customers and you want t
 
 Please note that if a different user is logged in, the Customer Hub id for the currently logged in user is stored in the Customer Hub cookie. The id contained in the Customer Hub cookie always takes precedence over an id specified using the `clabId` query string parameter.
 
-#### Setting `target` via query parameter
+#### Aggregate nodes
 
-The config's `target` option can also be set using the `target` parameter in the query string (`?target=AGGREGATE`).
+The SDK can handle also [aggregate nodes](https://explore.contactlab.com/understanding-nodes-and-trees/?lang=en).
+
+In order to send data to this kind of nodes (instead of standard "entry" ones), you have to set these optional configuration properties:
+
+- `target` to `AGGREGATE`;
+- `aggregateNodeId` to the aggregate node's id (found in the Customer Hub admin area);
+- `aggregateToken` to the aggregate node's token (found in the Customer Hub admin area).
+
+Please be aware that customer's creation and updating **are bypassed** when `target` is `AGGREGATE`, but reconciliation and id conflict resolution keep executing.
+
+Just as `clabId` also the `target` property can be set using the `target` parameter in the query string (`?target=AGGREGATE`).
 
 ## Contributing to this library
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,8 @@ This also offers an advantage that if the visitor to your webpage has already do
 
 To load a hosted library, copy and paste the HTML snippet for that library (shown below) in your web page.
 
+**Warning! The SDK is published in [UMD](https://github.com/umdjs/umd) format: if you use non-standard ways to load scripts in page (like [RequireJS](https://requirejs.org/)), please refer to the corresponding documentation.**
+
 #### ES6 version minified
 
 ```html

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,8 +93,9 @@ ch('config', {
   workspaceId: 'w_id', // required, found in the Customer Hub admin area
   nodeId: 'node_id', // required, found in the Customer Hub admin area
   token: 'UYTF546FUTF636JH', // required, found in the Customer Hub admin area
+  target: 'ENTRY', // optional, can be "ENTRY" or "AGGREGATE", defaults to "ENTRY"
   context: 'CTX', // optional, defaults to 'WEB'
-  contextInfo: {} // optional, defaults to an empty object,
+  contextInfo: {} // optional, defaults to an empty object
 });
 ```
 
@@ -250,7 +251,7 @@ ch('customer', {
 });
 ```
 
-#### The clabId query parameter
+#### The `clabId` query parameter
 
 You can also send a Customer Hub id using the `clabId` parameter in the query string (`?clabId=A_VALID_CONTACTHUB_ID`). This is transformed by the library in the following call:
 
@@ -260,8 +261,11 @@ ch('customer', {id: clabId});
 
 An example use case is if you send a newsletter to your customers and you want to make sure that if they reach your website from a link contained in the email, they are immediately recognised even if they are not logged in.
 
-Please note that if a different user is logged in, the Customer Hub id for the currently logged in user is stored in the Customer Hub cookie. The id contained in the Customer Hub cookie always takes precedence over an id specified using the
-`clabId` query string parameter.
+Please note that if a different user is logged in, the Customer Hub id for the currently logged in user is stored in the Customer Hub cookie. The id contained in the Customer Hub cookie always takes precedence over an id specified using the `clabId` query string parameter.
+
+#### Setting `target` via query parameter
+
+The config's `target` option can also be set using the `target` parameter in the query string (`?target=AGGREGATE`).
 
 ## Contributing to this library
 

--- a/docs/modules/config.ts.md
+++ b/docs/modules/config.ts.md
@@ -79,9 +79,12 @@ export interface ConfigOptions {
   token: string;
   workspaceId: string;
   nodeId: string;
+  target?: 'ENTRY' | 'AGGREGATE';
   context?: string;
   contextInfo?: Record<string, unknown>;
   debug?: boolean;
+  aggregateToken?: string;
+  aggregateNodeId?: string;
 }
 ```
 

--- a/docs/modules/cookie.ts.md
+++ b/docs/modules/cookie.ts.md
@@ -21,6 +21,7 @@ Added in v2.0.0
 - [model](#model)
   - [Cookie (interface)](#cookie-interface)
   - [HubCookie (interface)](#hubcookie-interface)
+  - [HubCookieWithTarget (interface)](#hubcookiewithtarget-interface)
   - [UTMCookie (interface)](#utmcookie-interface)
 - [utils](#utils)
   - [CookieGet (interface)](#cookieget-interface)
@@ -69,7 +70,7 @@ export interface Cookie {
   /**
    * Gets the Hub cookie.
    */
-  getHub: CookieGet<HubCookie>;
+  getHub: CookieGet<HubCookie, HubCookieWithTarget>;
   /**
    * Sets the Hub cookie.
    */
@@ -112,6 +113,20 @@ export interface HubCookie {
 
 Added in v2.0.0
 
+## HubCookieWithTarget (interface)
+
+Makes mandatory the SDK's cookie `target` property.
+
+**Signature**
+
+```ts
+export interface HubCookieWithTarget extends HubCookie {
+  target: Exclude<HubCookie['target'], undefined>;
+}
+```
+
+Added in v2.1.0
+
 ## UTMCookie (interface)
 
 Defines the shape of the UTM cookie value.
@@ -137,8 +152,8 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export interface CookieGet<A> {
-  (fallback?: A): Effect<A>;
+export interface CookieGet<B, A extends B = B> {
+  (fallback?: B): Effect<A>;
 }
 ```
 

--- a/docs/modules/cookie.ts.md
+++ b/docs/modules/cookie.ts.md
@@ -104,6 +104,9 @@ export interface HubCookie {
   sid: string;
   customerId?: string;
   hash?: string;
+  target?: 'ENTRY' | 'AGGREGATE';
+  aggregateToken?: string;
+  aggregateNodeId?: string;
 }
 ```
 

--- a/docs/modules/target.ts.md
+++ b/docs/modules/target.ts.md
@@ -1,0 +1,34 @@
+---
+title: target.ts
+nav_order: 10
+parent: Modules
+---
+
+## target overview
+
+Utilities related to `target` node.
+
+Added in v2.1.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [getNodeAndToken](#getnodeandtoken)
+
+---
+
+# utils
+
+## getNodeAndToken
+
+Gets the node id and token based on `target`.
+
+**Signature**
+
+```ts
+export declare const getNodeAndToken: (c: HubCookie) => Effect<NodeAndToken>;
+```
+
+Added in v2.1.0

--- a/docs/modules/target.ts.md
+++ b/docs/modules/target.ts.md
@@ -28,7 +28,9 @@ Gets the node id and token based on `target`.
 **Signature**
 
 ```ts
-export declare const getNodeAndToken: (c: HubCookie) => Effect<NodeAndToken>;
+export declare const getNodeAndToken: (
+  c: HubCookieWithTarget
+) => Effect<NodeAndToken>;
 ```
 
 Added in v2.1.0

--- a/docs/modules/uuid.ts.md
+++ b/docs/modules/uuid.ts.md
@@ -1,6 +1,6 @@
 ---
 title: uuid.ts
-nav_order: 10
+nav_order: 11
 parent: Modules
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6236,9 +6236,9 @@
       }
     },
     "js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.0.tgz",
+      "integrity": "sha512-oUbbplKuH07/XX2YD2+Q+GMiPpnVXaRz8npE7suhBH9QEkJe2W7mQ6rwuMXHue3fpfcftQwzgyvGzIHyfCSngQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -9138,29 +9138,19 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "27.0.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.0.4.tgz",
-      "integrity": "sha512-c4E1ECy9Xz2WGfTMyHbSaArlIva7Wi2p43QOMmCqjSSjHP06KXv+aT+eSY+yZMuqsMi3k7pyGsGj2q5oSl5WfQ==",
+      "version": "27.0.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.0.5.tgz",
+      "integrity": "sha512-lIJApzfTaSSbtlksfFNHkWOzLJuuSm4faFAfo5kvzOiRAuoN4/eKxVJ2zEAho8aecE04qX6K1pAzfH5QHL1/8w==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
-        "buffer-from": "1.x",
         "fast-json-stable-stringify": "2.x",
         "jest-util": "^27.0.0",
         "json5": "2.x",
         "lodash": "4.x",
         "make-error": "1.x",
-        "mkdirp": "1.x",
         "semver": "7.x",
         "yargs-parser": "20.x"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        }
       }
     },
     "ts-loader": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cross-fetch": "3.1.4",
     "es6-promise": "4.2.8",
     "fp-ts": "2.11.1",
-    "js-cookie": "2.2.1",
+    "js-cookie": "3.0.0",
     "jssha": "3.2.0",
     "tslib": "2.3.1",
     "uuid": "8.3.2"
@@ -76,7 +76,7 @@
     "pretty-quick": "3.1.1",
     "puppeteer": "10.2.0",
     "sinon": "11.1.2",
-    "ts-jest": "27.0.4",
+    "ts-jest": "27.0.5",
     "ts-loader": "9.2.5",
     "ts-node": "10.2.0",
     "typescript": "4.3.5",

--- a/scripts/docs.ts
+++ b/scripts/docs.ts
@@ -9,7 +9,7 @@ const sequenceTE = sequenceT(TE.ApplicativePar);
 
 const readFileTE = TE.taskify<
   fs.PathLike,
-  string,
+  BufferEncoding,
   NodeJS.ErrnoException,
   string
 >(fs.readFile);
@@ -33,7 +33,7 @@ const copyInDocs = (
   headline: string
 ): TE.TaskEither<Error, void> =>
   pipe(
-    TE.fromIO<Error, void>(info(`Copy content of ${source} into ${dest}...`)),
+    TE.fromIO<void, Error>(info(`Copy content of ${source} into ${dest}...`)),
     TE.chain(() => readFileTE(source, 'utf8')),
     TE.map(content => `${headline}${content}`),
     TE.chain(content => writeFileTE(dest, content)),

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -104,6 +104,9 @@ export interface HubCookie {
   sid: string;
   customerId?: string;
   hash?: string;
+  target?: 'ENTRY' | 'AGGREGATE';
+  aggregateToken?: string;
+  aggregateNodeId?: string;
 }
 
 const CHDecoder: Decoder<HubCookie> = u => {

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -38,7 +38,7 @@ export interface Cookie {
   /**
    * Gets the Hub cookie.
    */
-  getHub: CookieGet<HubCookie>;
+  getHub: CookieGet<HubCookie, HubCookieWithTarget>;
   /**
    * Sets the Hub cookie.
    */
@@ -56,8 +56,8 @@ export interface Cookie {
 /**
  * @since 2.0.0
  */
-export interface CookieGet<A> {
-  (fallback?: A): Effect<A>;
+export interface CookieGet<B, A extends B = B> {
+  (fallback?: B): Effect<A>;
 }
 
 /**
@@ -80,7 +80,11 @@ export const cookie = (): Cookie => {
     (window as WithVars).ContactHubUtmCookie ?? '_chutm';
 
   return {
-    getHub: fallback => get(hubName(), CHDecoder, fallback),
+    getHub: fallback =>
+      pipe(
+        get(hubName(), CHDecoder, fallback),
+        TE.map(ch => ({...ch, target: ch.target || 'ENTRY'}))
+      ),
     setHub: (value, opts) => set(hubName(), value, opts),
     getUTM: fallback => get(utmName(), UTMDecoder, fallback),
     setUTM: (value, opts) => set(utmName(), value, opts)
@@ -107,6 +111,16 @@ export interface HubCookie {
   target?: 'ENTRY' | 'AGGREGATE';
   aggregateToken?: string;
   aggregateNodeId?: string;
+}
+
+/**
+ * Makes mandatory the SDK's cookie `target` property.
+ *
+ * @category model
+ * @since 2.1.0
+ */
+export interface HubCookieWithTarget extends HubCookie {
+  target: Exclude<HubCookie['target'], undefined>;
 }
 
 const CHDecoder: Decoder<HubCookie> = u => {

--- a/src/event.ts
+++ b/src/event.ts
@@ -9,6 +9,7 @@ import {DocumentSvc} from './doc';
 import {HttpSvc} from './http';
 import {LocationSvc} from './location';
 import {Effect} from './program';
+import {getNodeAndToken} from './target';
 
 /**
  * Defines capabilities and services required by the `event` method in order to work.
@@ -65,16 +66,11 @@ export const event =
           TE.altW(() => TE.right(undefined))
         )
       ),
-      TE.chain(({cookie, opts, utm}) => {
-        const {
-          token,
-          workspaceId,
-          nodeId,
-          context,
-          contextInfo,
-          customerId,
-          sid
-        } = cookie;
+      // TODO: is this right? should the operation fail if target is AGGREGATE but aggregateNodeId and aggregateToken are not defined?
+      TE.bind('nt', ({cookie}) => getNodeAndToken(cookie)),
+      TE.chain(({cookie, opts, utm, nt}) => {
+        const {token, nodeId} = nt;
+        const {workspaceId, context, contextInfo, customerId, sid} = cookie;
 
         const properties = inferProperties(E)(opts);
         const tracking = typeof utm === 'undefined' ? utm : {ga: utm};

--- a/src/target.ts
+++ b/src/target.ts
@@ -1,0 +1,35 @@
+/**
+ * Utilities related to `target` node.
+ *
+ * @since 2.1.0
+ */
+
+import * as TE from 'fp-ts/TaskEither';
+import {HubCookie} from './cookie';
+import {Effect} from './program';
+
+interface NodeAndToken {
+  nodeId: string;
+  token: string;
+}
+
+/**
+ * Gets the node id and token based on `target`.
+ *
+ * @since 2.1.0
+ */
+export const getNodeAndToken = (c: HubCookie): Effect<NodeAndToken> => {
+  const target = c.target || 'ENTRY';
+
+  if (target === 'ENTRY') {
+    return TE.right({nodeId: c.nodeId, token: c.token});
+  }
+
+  return c.aggregateNodeId && c.aggregateToken
+    ? TE.right({nodeId: c.aggregateNodeId, token: c.aggregateToken})
+    : TE.left(
+        new Error(
+          '"aggregateNodeId" and "aggregateToken" must be set when "target" is "AGGREGATE"'
+        )
+      );
+};

--- a/src/target.ts
+++ b/src/target.ts
@@ -5,7 +5,7 @@
  */
 
 import * as TE from 'fp-ts/TaskEither';
-import {HubCookie} from './cookie';
+import {HubCookieWithTarget} from './cookie';
 import {Effect} from './program';
 
 interface NodeAndToken {
@@ -18,10 +18,10 @@ interface NodeAndToken {
  *
  * @since 2.1.0
  */
-export const getNodeAndToken = (c: HubCookie): Effect<NodeAndToken> => {
-  const target = c.target || 'ENTRY';
-
-  if (target === 'ENTRY') {
+export const getNodeAndToken = (
+  c: HubCookieWithTarget
+): Effect<NodeAndToken> => {
+  if (c.target === 'ENTRY') {
     return TE.right({nodeId: c.nodeId, token: c.token});
   }
 

--- a/test/_helpers.ts
+++ b/test/_helpers.ts
@@ -1,3 +1,5 @@
+import Cookies from 'js-cookie';
+
 export const CH = '_ch';
 export const UTM = '_chutm';
 export const WSID = 'wsid';
@@ -42,3 +44,14 @@ export const wait = (): Promise<void> =>
   new Promise(resolve => {
     setTimeout(() => resolve(undefined), 2);
   });
+
+// --- Cookie utilities
+export const removeCookie = Cookies.remove;
+
+export const getCookie = Cookies.get;
+
+export const getCookieJSON = (name: string): any =>
+  JSON.parse(Cookies.get(name) || '{}');
+
+export const setCookieJSON = (name: string, value: any): string | undefined =>
+  Cookies.set(name, JSON.stringify(value));

--- a/test/cookie.spec.ts
+++ b/test/cookie.spec.ts
@@ -18,6 +18,7 @@ afterEach(() => {
 
 test('cookie.getHub() should return current value of Hub cookie', async () => {
   const HUB_COOKIE: HubCookie = {
+    target: 'ENTRY',
     token: H.TOKEN,
     workspaceId: H.WSID,
     nodeId: H.NID,
@@ -38,6 +39,7 @@ test('cookie.getHub() should return current value of Hub cookie - use configured
   (window as any).ContactHubCookie = '_foo';
 
   const HUB_COOKIE: HubCookie = {
+    target: 'ENTRY',
     token: H.TOKEN,
     workspaceId: H.WSID,
     nodeId: H.NID,
@@ -58,6 +60,7 @@ test('cookie.getHub() should return current value of Hub cookie - use configured
 
 test('cookie.getHub() should return current value of Hub cookie - with fallback', async () => {
   const HUB_COOKIE_FALLBACK: HubCookie = {
+    target: 'ENTRY',
     token: H.TOKEN,
     workspaceId: H.WSID,
     nodeId: H.NID,
@@ -102,6 +105,7 @@ test('cookie.getHub() should return current value of Hub cookie - parse error', 
 
 test('cookie.setHub() should set provided Hub cookie', async () => {
   const HUB_COOKIE: HubCookie = {
+    target: 'ENTRY',
     token: H.TOKEN,
     workspaceId: H.WSID,
     nodeId: H.NID,

--- a/test/cookie.spec.ts
+++ b/test/cookie.spec.ts
@@ -35,6 +35,24 @@ test('cookie.getHub() should return current value of Hub cookie', async () => {
   expect(result).toEqual(right(HUB_COOKIE));
 });
 
+test('cookie.getHub() should return current value of Hub cookie - target fallback to `ENTRY`', async () => {
+  const HUB_COOKIE: HubCookie = {
+    token: H.TOKEN,
+    workspaceId: H.WSID,
+    nodeId: H.NID,
+    debug: false,
+    context: 'WEB',
+    contextInfo: {},
+    sid: 'ABCD-1234'
+  };
+
+  H.setCookieJSON(H.CH, HUB_COOKIE);
+
+  const result = await cookie().getHub()();
+
+  expect(result).toEqual(right({...HUB_COOKIE, target: 'ENTRY'}));
+});
+
 test('cookie.getHub() should return current value of Hub cookie - use configured cookie name', async () => {
   (window as any).ContactHubCookie = '_foo';
 

--- a/test/cookie.spec.ts
+++ b/test/cookie.spec.ts
@@ -3,15 +3,14 @@
  */
 
 import {left, right} from 'fp-ts/Either';
-import Cookies from 'js-cookie';
 import {cookie, HubCookie, UTMCookie} from '../src/cookie';
 import * as H from './_helpers';
 
 afterEach(() => {
   jest.clearAllMocks();
 
-  Cookies.remove(H.CH);
-  Cookies.remove(H.UTM);
+  H.removeCookie(H.CH);
+  H.removeCookie(H.UTM);
 
   (window as any).ContactHubCookie = undefined;
   (window as any).ContactHubUtmCookie = undefined;
@@ -28,7 +27,7 @@ test('cookie.getHub() should return current value of Hub cookie', async () => {
     sid: 'ABCD-1234'
   };
 
-  Cookies.set(H.CH, HUB_COOKIE);
+  H.setCookieJSON(H.CH, HUB_COOKIE);
 
   const result = await cookie().getHub()();
 
@@ -48,13 +47,13 @@ test('cookie.getHub() should return current value of Hub cookie - use configured
     sid: 'ABCD-1234'
   };
 
-  Cookies.set('_foo', HUB_COOKIE);
+  H.setCookieJSON('_foo', HUB_COOKIE);
 
   const result = await cookie().getHub()();
 
   expect(result).toEqual(right(HUB_COOKIE));
 
-  Cookies.remove('_foo');
+  H.removeCookie('_foo');
 });
 
 test('cookie.getHub() should return current value of Hub cookie - with fallback', async () => {
@@ -80,7 +79,7 @@ test('cookie.getHub() should return current value of Hub cookie - not found', as
 });
 
 test('cookie.getHub() should return current value of Hub cookie - decoding error', async () => {
-  Cookies.set(H.CH, {token: H.TOKEN});
+  H.setCookieJSON(H.CH, {token: H.TOKEN});
 
   const result = await cookie().getHub()();
 
@@ -91,7 +90,7 @@ test('cookie.getHub() should return current value of Hub cookie - decoding error
 
 test('cookie.getHub() should return current value of Hub cookie - parse error', async () => {
   // Parse will fail because of trailing comma
-  Cookies.set(
+  H.setCookieJSON(
     H.CH,
     '{"token":"ABC123","workspaceId":"workspace_id","nodeId":"node_id","sid":"ABCD-1234",}'
   );
@@ -116,7 +115,7 @@ test('cookie.setHub() should set provided Hub cookie', async () => {
 
   expect(result).toEqual(right(undefined));
 
-  expect(Cookies.getJSON(H.CH)).toEqual(HUB_COOKIE);
+  expect(H.getCookieJSON(H.CH)).toEqual(HUB_COOKIE);
 });
 
 test('cookie.setHub() should set provided Hub cookie - use configured cookie name', async () => {
@@ -136,9 +135,9 @@ test('cookie.setHub() should set provided Hub cookie - use configured cookie nam
 
   expect(result).toEqual(right(undefined));
 
-  expect(Cookies.getJSON('_foo')).toEqual(HUB_COOKIE);
+  expect(H.getCookieJSON('_foo')).toEqual(HUB_COOKIE);
 
-  Cookies.remove('_foo');
+  H.removeCookie('_foo');
 });
 
 test('cookie.setHub() should fail if provided Hub cookie cannot be stringified', async () => {
@@ -163,7 +162,7 @@ test('cookie.setHub() should fail if provided Hub cookie cannot be stringified',
     )
   );
 
-  expect(Cookies.get(H.CH)).toBe(undefined);
+  expect(H.getCookie(H.CH)).toBe(undefined);
 });
 
 test('cookie.getUTM() should return current value of UTM cookie', async () => {
@@ -172,7 +171,7 @@ test('cookie.getUTM() should return current value of UTM cookie', async () => {
     utm_medium: 'web'
   };
 
-  Cookies.set(H.UTM, UTM_COOKIE);
+  H.setCookieJSON(H.UTM, UTM_COOKIE);
 
   const result = await cookie().getUTM()();
 
@@ -187,13 +186,13 @@ test('cookie.getUTM() should return current value of UTM cookie - use configured
     utm_medium: 'web'
   };
 
-  Cookies.set('_foo', UTM_COOKIE);
+  H.setCookieJSON('_foo', UTM_COOKIE);
 
   const result = await cookie().getUTM()();
 
   expect(result).toEqual(right(UTM_COOKIE));
 
-  Cookies.remove('_foo');
+  H.removeCookie('_foo');
 });
 
 test('cookie.getUTM() should return current value of UTM cookie - with fallback', async () => {
@@ -223,7 +222,7 @@ test('cookie.setUTM() should set provided UTM cookie', async () => {
 
   expect(result).toEqual(right(undefined));
 
-  expect(Cookies.getJSON(H.UTM)).toEqual(UTM_COOKIE);
+  expect(H.getCookieJSON(H.UTM)).toEqual(UTM_COOKIE);
 });
 
 test('cookie.setUTM() should set provided UTM cookie - use configured cookie name', async () => {
@@ -238,9 +237,9 @@ test('cookie.setUTM() should set provided UTM cookie - use configured cookie nam
 
   expect(result).toEqual(right(undefined));
 
-  expect(Cookies.getJSON('_foo')).toEqual(UTM_COOKIE);
+  expect(H.getCookieJSON('_foo')).toEqual(UTM_COOKIE);
 
-  Cookies.remove('_foo');
+  H.removeCookie('_foo');
 });
 
 test('cookie.setUTM() should fail if provided UTM cookie cannot be stringified', async () => {
@@ -260,5 +259,5 @@ test('cookie.setUTM() should fail if provided UTM cookie cannot be stringified',
     )
   );
 
-  expect(Cookies.get(H.UTM)).toBe(undefined);
+  expect(H.getCookie(H.UTM)).toBe(undefined);
 });

--- a/test/customer.spec.ts
+++ b/test/customer.spec.ts
@@ -23,7 +23,7 @@ test('customer() should reset Hub cookie when called without options', async () 
   expect(_HTTP.patch).not.toBeCalled();
   expect(S.SET_HUB_COOKIE).toBeCalledWith(
     {
-      ...S.HUB_COOKIE,
+      ...S.HUB_COOKIE(),
       sid: S.UUID_STR,
       customerId: undefined,
       hash: undefined
@@ -45,13 +45,13 @@ test('customer() should reconcile and update when customer id is provided but is
   expect(_HTTP.post).toBeCalledTimes(1); // <-- `shouldUpdate` is false because;
   expect(_HTTP.post).toBeCalledWith(
     `/workspaces/${H.WSID}/customers/abcd1234/sessions`,
-    {value: S.HUB_COOKIE.sid},
+    {value: S.HUB_COOKIE().sid},
     H.TOKEN
   );
   expect(_HTTP.patch).not.toBeCalled();
   expect(S.SET_HUB_COOKIE).toBeCalledWith(
     {
-      ...S.HUB_COOKIE,
+      ...S.HUB_COOKIE(),
       customerId: 'abcd1234',
       hash: '44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a'
     },
@@ -59,11 +59,42 @@ test('customer() should reconcile and update when customer id is provided but is
   );
 });
 
+test('customer() should reconcile and update when customer id is provided but is not in cookie - nodeId and target fallback', async () => {
+  const c = customer({
+    http: _HTTP,
+    cookie: S.COOKIE({hub: TE.right({...S.HUB_COOKIE(), target: 'AGGREGATE'})}),
+    uuid: S.UUID
+  });
+
+  const result = await c({id: 'abcd1234'})();
+
+  // the entire operation fails because `update` fails (no aggregate nodeId and token in hub cookie)
+  expect(result).toEqual(
+    left(
+      new Error(
+        '"aggregateNodeId" and "aggregateToken" must be set when "target" is "AGGREGATE"'
+      )
+    )
+  );
+
+  // so `update` and `store` are bypassed
+  expect(_HTTP.patch).not.toBeCalled();
+  expect(S.SET_HUB_COOKIE).not.toBeCalled();
+
+  // `reconcile` succeeds instead
+  expect(_HTTP.post).toBeCalledTimes(1);
+  expect(_HTTP.post).toBeCalledWith(
+    `/workspaces/${H.WSID}/customers/abcd1234/sessions`,
+    {value: S.HUB_COOKIE().sid},
+    H.TOKEN
+  );
+});
+
 test('customer() should update when customer id is in cookie', async () => {
   const c = customer({
     http: _HTTP,
     cookie: S.COOKIE({
-      hub: TE.right(S.HUB_COOKIE_CID)
+      hub: TE.right(S.HUB_COOKIE_CID())
     }),
     uuid: S.UUID
   });
@@ -80,7 +111,7 @@ test('customer() should update when customer id is in cookie', async () => {
   );
   expect(S.SET_HUB_COOKIE).toBeCalledWith(
     {
-      ...S.HUB_COOKIE_CID,
+      ...S.HUB_COOKIE_CID(),
       hash: 'e7489d96d261f13e4caaf12ac7145bf4d86ac81136af76532877a91e4f8b58a0'
     },
     undefined
@@ -91,7 +122,7 @@ test('customer() should resolve and update when customer id is provided and is i
   const c = customer({
     http: _HTTP,
     cookie: S.COOKIE({
-      hub: TE.right(S.HUB_COOKIE_CID)
+      hub: TE.right(S.HUB_COOKIE_CID())
     }),
     uuid: S.UUID
   });
@@ -104,7 +135,7 @@ test('customer() should resolve and update when customer id is provided and is i
   expect(result).toEqual(right(undefined));
   expect(S.SET_HUB_COOKIE).toBeCalledWith(
     {
-      ...S.HUB_COOKIE,
+      ...S.HUB_COOKIE(),
       sid: S.UUID_STR,
       customerId: undefined,
       hash: undefined
@@ -125,7 +156,7 @@ test('customer() should resolve and update when customer id is provided and is i
   );
   expect(S.SET_HUB_COOKIE).toBeCalledWith(
     {
-      ...S.HUB_COOKIE,
+      ...S.HUB_COOKIE(),
       sid: S.UUID_STR,
       customerId: 'efgh5678',
       hash: 'e7489d96d261f13e4caaf12ac7145bf4d86ac81136af76532877a91e4f8b58a0'
@@ -138,7 +169,7 @@ test('customer() should only update when customer id is provided and is in cooki
   const c = customer({
     http: _HTTP,
     cookie: S.COOKIE({
-      hub: TE.right(S.HUB_COOKIE_CID)
+      hub: TE.right(S.HUB_COOKIE_CID())
     }),
     uuid: S.UUID
   });
@@ -159,7 +190,7 @@ test('customer() should only update when customer id is provided and is in cooki
   expect(S.SET_HUB_COOKIE).toBeCalledTimes(1);
   expect(S.SET_HUB_COOKIE).toBeCalledWith(
     {
-      ...S.HUB_COOKIE_CID,
+      ...S.HUB_COOKIE_CID(),
       hash: 'e7489d96d261f13e4caaf12ac7145bf4d86ac81136af76532877a91e4f8b58a0'
     },
     undefined
@@ -197,7 +228,7 @@ test('customer() should create and reconcile when no customer id is provided or 
   );
   expect(S.SET_HUB_COOKIE).toBeCalledWith(
     {
-      ...S.HUB_COOKIE,
+      ...S.HUB_COOKIE(),
       customerId: 'abcd1234',
       hash: 'e7489d96d261f13e4caaf12ac7145bf4d86ac81136af76532877a91e4f8b58a0'
     },
@@ -205,7 +236,7 @@ test('customer() should create and reconcile when no customer id is provided or 
   );
   expect(HTTP_CREATE.post).toBeCalledWith(
     `/workspaces/${H.WSID}/customers/abcd1234/sessions`,
-    {value: S.HUB_COOKIE.sid},
+    {value: S.HUB_COOKIE().sid},
     H.TOKEN
   );
 });
@@ -215,7 +246,7 @@ test('customer() should do nothing if data are the same', async () => {
     http: _HTTP,
     cookie: S.COOKIE({
       hub: TE.right({
-        ...S.HUB_COOKIE_CID,
+        ...S.HUB_COOKIE_CID(),
         hash: 'e7489d96d261f13e4caaf12ac7145bf4d86ac81136af76532877a91e4f8b58a0'
       })
     }),
@@ -323,7 +354,7 @@ test('customer() should fail when customer id conflict cannot be resolved', asyn
   const c = customer({
     http: _HTTP,
     cookie: S.COOKIE({
-      hub: TE.right(S.HUB_COOKIE_CID)
+      hub: TE.right(S.HUB_COOKIE_CID())
     }),
     uuid: S.UUID
   });

--- a/test/event.spec.ts
+++ b/test/event.spec.ts
@@ -14,7 +14,7 @@ test('event() should send an event to API', async () => {
     location: S.LOCATION(),
     http: _HTTP,
     cookie: S.COOKIE({
-      hub: TE.right(S.HUB_COOKIE_CID),
+      hub: TE.right(S.HUB_COOKIE_CID()),
       utm: TE.left(new Error())
     }),
     document: S.DOC({})
@@ -46,7 +46,7 @@ test('event() should send an event to API - with tracking', async () => {
     location: S.LOCATION(),
     http: _HTTP,
     cookie: S.COOKIE({
-      hub: TE.right(S.HUB_COOKIE_CID)
+      hub: TE.right(S.HUB_COOKIE_CID())
     }),
     document: S.DOC({})
   });
@@ -99,7 +99,7 @@ test('event() should send an event to API - with bringBackProperties', async () 
       customerId: undefined,
       bringBackProperties: {
         type: 'SESSION_ID',
-        value: S.HUB_COOKIE.sid,
+        value: S.HUB_COOKIE().sid,
         nodeId: H.NID
       }
     },
@@ -112,7 +112,7 @@ test('event() should send an event to API - with inferred properties', async () 
     location: S.LOCATION(),
     http: _HTTP,
     cookie: S.COOKIE({
-      hub: TE.right(S.HUB_COOKIE_CID),
+      hub: TE.right(S.HUB_COOKIE_CID()),
       utm: TE.left(new Error())
     }),
     document: S.DOC({})
@@ -190,6 +190,31 @@ test('event() should fail if Hub cookie does not exists', async () => {
 
   expect(result).toEqual(
     left(new Error('Missing required ContactHub configuration.'))
+  );
+  expect(_HTTP.post).not.toBeCalled();
+});
+
+test('event() should fail if target is AGGREGATE but related nodeId and token are not defined', async () => {
+  const e = event({
+    location: S.LOCATION(),
+    http: _HTTP,
+    cookie: S.COOKIE({
+      hub: TE.right({...S.HUB_COOKIE(), target: 'AGGREGATE'})
+    }),
+    document: S.DOC({})
+  });
+
+  const result = await e({
+    type: 'completedOrder',
+    properties: {orderId: '1234'}
+  })();
+
+  expect(result).toEqual(
+    left(
+      new Error(
+        '"aggregateNodeId" and "aggregateToken" must be set when "target" is "AGGREGATE"'
+      )
+    )
   );
   expect(_HTTP.post).not.toBeCalled();
 });

--- a/test/integration/config.test.ts
+++ b/test/integration/config.test.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
-import Cookies from 'js-cookie';
+import * as C from '../_helpers';
 import * as H from './_helpers';
 
 describe('Config API', () => {
   beforeEach(async () => {
-    Cookies.remove(H.CH);
+    C.removeCookie(H.CH);
   });
 
   afterEach(() => {
@@ -17,26 +17,26 @@ describe('Config API', () => {
     const uuidV4 =
       /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
 
-    expect(typeof Cookies.get(H.CH)).not.to.equal(undefined);
-    expect(uuidV4.test(Cookies.getJSON(H.CH).sid)).to.equal(true);
+    expect(typeof C.getCookie(H.CH)).not.to.equal(undefined);
+    expect(uuidV4.test(C.getCookieJSON(H.CH).sid)).to.equal(true);
   });
 
   it('should not regenerate sessionId if already present', async () => {
     await H.setConfig();
 
-    const sid = Cookies.getJSON(H.CH).sid;
+    const sid = C.getCookieJSON(H.CH).sid;
 
     H._ch('config', H.CONFIG);
 
     await H.whenDone();
 
-    expect(Cookies.getJSON(H.CH).sid).to.equal(sid);
+    expect(C.getCookieJSON(H.CH).sid).to.equal(sid);
   });
 
   it('should store all config data in the cookie and uses defaults', async () => {
     await H.setConfig();
 
-    const c = Cookies.getJSON(H.CH);
+    const c = C.getCookieJSON(H.CH);
 
     expect(c.workspaceId).to.equal(H.WSID);
     expect(c.nodeId).to.equal(H.NID);
@@ -57,7 +57,7 @@ describe('Config API', () => {
 
     await H.whenDone();
 
-    const c = Cookies.getJSON(H.CH);
+    const c = C.getCookieJSON(H.CH);
 
     expect(c.context).to.equal('foo');
     expect(c.contextInfo).to.eql({foo: 'bar'});
@@ -65,8 +65,8 @@ describe('Config API', () => {
   });
 
   it('should remove user data from cookie if the token changes', async () => {
-    Cookies.set(H.CH, {
-      ...Cookies.getJSON(H.CH),
+    C.setCookieJSON(H.CH, {
+      ...C.getCookieJSON(H.CH),
       customerId: H.CID,
       token: H.TOKEN
     });
@@ -75,7 +75,7 @@ describe('Config API', () => {
 
     await H.whenDone();
 
-    const c = Cookies.getJSON(H.CH);
+    const c = C.getCookieJSON(H.CH);
 
     expect(c.token).to.equal('CDE456');
     expect(c.customerId).to.equal(undefined);

--- a/test/integration/consents.test.ts
+++ b/test/integration/consents.test.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
-import Cookies from 'js-cookie';
+import * as C from '../_helpers';
 import * as H from './_helpers';
 
 describe('Consents', () => {
   beforeEach(() => {
-    Cookies.remove(H.CH);
+    C.removeCookie(H.CH);
   });
 
   afterEach(() => {
@@ -37,7 +37,7 @@ describe('Consents', () => {
 
     await H.setConfig();
 
-    Cookies.set(H.CH, {...Cookies.getJSON(H.CH), customerId: H.CID});
+    C.setCookieJSON(H.CH, {...C.getCookieJSON(H.CH), customerId: H.CID});
 
     H._ch('customer', H.CUSTOMER);
 

--- a/test/integration/customer.test.ts
+++ b/test/integration/customer.test.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
-import Cookies from 'js-cookie';
+import * as C from '../_helpers';
 import * as H from './_helpers';
 
 describe('Customer API:', () => {
   beforeEach(() => {
-    Cookies.remove(H.CH);
+    C.removeCookie(H.CH);
   });
 
   afterEach(() => {
@@ -56,7 +56,7 @@ describe('Customer API:', () => {
       expect(createHeaders.Authorization).to.equal(`Bearer ${H.TOKEN}`);
 
       // --- from cookie
-      const {customerId, hash, sid} = Cookies.getJSON(H.CH);
+      const {customerId, hash, sid} = C.getCookieJSON(H.CH);
 
       // --- store
       expect(customerId).to.equal(H.CID);
@@ -75,7 +75,7 @@ describe('Customer API:', () => {
 
       await H.setConfig();
 
-      Cookies.set(H.CH, {...Cookies.getJSON(H.CH), customerId: H.CID});
+      C.setCookieJSON(H.CH, {...C.getCookieJSON(H.CH), customerId: H.CID});
 
       H._ch('customer', H.CUSTOMER);
 
@@ -110,7 +110,7 @@ describe('Customer API:', () => {
     it('should not not make any API call if the same customerId is in cookie', async () => {
       await H.setConfig();
 
-      Cookies.set(H.CH, {...Cookies.getJSON(H.CH), customerId: H.CID});
+      C.setCookieJSON(H.CH, {...C.getCookieJSON(H.CH), customerId: H.CID});
 
       H._ch('customer', {id: H.CID});
 
@@ -122,8 +122,8 @@ describe('Customer API:', () => {
     it('should not make any API call if a different customerId is in cookie', async () => {
       await H.setConfig();
 
-      Cookies.set(H.CH, {
-        ...Cookies.getJSON(H.CH),
+      C.setCookieJSON(H.CH, {
+        ...C.getCookieJSON(H.CH),
         customerId: 'different-cid'
       });
 
@@ -140,14 +140,14 @@ describe('Customer API:', () => {
 
       await H.setConfig();
 
-      const {sid} = Cookies.getJSON(H.CH);
+      const {sid} = C.getCookieJSON(H.CH);
 
       H._ch('customer', {id: H.CID});
 
       await H.whenDone();
 
       // --- does not reset the sessionId
-      expect(Cookies.getJSON(H.CH).sid).to.eql(sid);
+      expect(C.getCookieJSON(H.CH).sid).to.eql(sid);
 
       // --- reconciles the sessionId with the customerId
       const body = H._fetchMock.lastOptions()?.body as unknown as string;
@@ -169,7 +169,7 @@ describe('Customer API:', () => {
 
       await H.setConfig();
 
-      Cookies.set(H.CH, {...Cookies.getJSON(H.CH), customerId: H.CID});
+      C.setCookieJSON(H.CH, {...C.getCookieJSON(H.CH), customerId: H.CID});
 
       H._ch('customer', {...H.CUSTOMER, id: H.CID});
 
@@ -189,18 +189,18 @@ describe('Customer API:', () => {
 
       await H.setConfig();
 
-      Cookies.set(H.CH, {
-        ...Cookies.getJSON(H.CH),
+      C.setCookieJSON(H.CH, {
+        ...C.getCookieJSON(H.CH),
         customerId: 'different-cid'
       });
 
-      const {sid} = Cookies.getJSON(H.CH);
+      const {sid} = C.getCookieJSON(H.CH);
 
       H._ch('customer', {...H.CUSTOMER, id: H.CID});
 
       await H.whenDone();
 
-      const newSid = Cookies.getJSON(H.CH).sid;
+      const newSid = C.getCookieJSON(H.CH).sid;
 
       const [reconcile, update] = H._fetchMock.calls();
 
@@ -228,13 +228,13 @@ describe('Customer API:', () => {
 
       await H.setConfig();
 
-      const {sid} = Cookies.getJSON(H.CH);
+      const {sid} = C.getCookieJSON(H.CH);
 
       H._ch('customer', {...H.CUSTOMER, id: H.CID});
 
       await H.whenDone();
 
-      const newSid = Cookies.getJSON(H.CH).sid;
+      const newSid = C.getCookieJSON(H.CH).sid;
 
       const [reconcile, update] = H._fetchMock.calls();
 
@@ -260,8 +260,8 @@ describe('Customer API:', () => {
     it('should remove user data from cookie and generate new session', async () => {
       await H.setConfig();
 
-      Cookies.set(H.CH, {
-        ...Cookies.getJSON(H.CH),
+      C.setCookieJSON(H.CH, {
+        ...C.getCookieJSON(H.CH),
         customerId: 'old-customer-id',
         sid: 'old-session-id'
       });
@@ -270,7 +270,7 @@ describe('Customer API:', () => {
 
       await H.whenDone();
 
-      const {customerId, sid} = Cookies.getJSON(H.CH);
+      const {customerId, sid} = C.getCookieJSON(H.CH);
 
       const sidRgx =
         /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
@@ -288,7 +288,7 @@ describe('Customer API:', () => {
     beforeEach(async () => {
       await H.setConfig();
 
-      Cookies.set(H.CH, {...Cookies.getJSON(H.CH), customerId: H.CID});
+      C.setCookieJSON(H.CH, {...C.getCookieJSON(H.CH), customerId: H.CID});
     });
 
     it('should log errors if id != customerId and no other customer data provided', async () => {
@@ -399,7 +399,7 @@ describe('Customer API:', () => {
 
       await H.setConfig();
 
-      Cookies.set(H.CH, {...Cookies.getJSON(H.CH), customerId: H.CID});
+      C.setCookieJSON(H.CH, {...C.getCookieJSON(H.CH), customerId: H.CID});
 
       H._ch('customer', {externalId: 'ANOTHER_ID'});
 

--- a/test/integration/event.test.ts
+++ b/test/integration/event.test.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
-import Cookies from 'js-cookie';
+import * as C from '../_helpers';
 import * as H from './_helpers';
 
 describe('Event API', () => {
   beforeEach(() => {
-    Cookies.remove(H.CH);
+    C.removeCookie(H.CH);
 
     H._fetchMock.post(`${H.API}/workspaces/${H.WSID}/events`, 200);
   });
@@ -48,7 +48,7 @@ describe('Event API', () => {
     expect(body.type).to.equal('viewedPage');
     expect(body.bringBackProperties).to.eql({
       type: 'SESSION_ID',
-      value: Cookies.getJSON(H.CH).sid,
+      value: C.getCookieJSON(H.CH).sid,
       nodeId: H.NID
     });
   });
@@ -56,7 +56,7 @@ describe('Event API', () => {
   it('should send customerId when available in cookie', async () => {
     await H.setConfig();
 
-    Cookies.set(H.CH, {...Cookies.getJSON(H.CH), customerId: H.CID});
+    C.setCookieJSON(H.CH, {...C.getCookieJSON(H.CH), customerId: H.CID});
 
     H._ch('event', {type: 'viewedPage'});
 
@@ -70,7 +70,7 @@ describe('Event API', () => {
   it('should omit bringBackProperties when customerId is available', async () => {
     await H.setConfig();
 
-    Cookies.set(H.CH, {...Cookies.getJSON(H.CH), customerId: H.CID});
+    C.setCookieJSON(H.CH, {...C.getCookieJSON(H.CH), customerId: H.CID});
 
     H._ch('event', {type: 'viewedPage'});
 
@@ -131,7 +131,7 @@ describe('Event API', () => {
   it('should get the "context" from the cookie', async () => {
     await H.setConfig();
 
-    Cookies.set(H.CH, {...Cookies.getJSON(H.CH), context: 'FOO'});
+    C.setCookieJSON(H.CH, {...C.getCookieJSON(H.CH), context: 'FOO'});
 
     H._ch('event', {type: 'viewedPage'});
 
@@ -145,7 +145,10 @@ describe('Event API', () => {
   it('should get the "contextInfo" from the cookie', async () => {
     await H.setConfig();
 
-    Cookies.set(H.CH, {...Cookies.getJSON(H.CH), contextInfo: {foo: 'bar'}});
+    C.setCookieJSON(H.CH, {
+      ...C.getCookieJSON(H.CH),
+      contextInfo: {foo: 'bar'}
+    });
 
     H._ch('event', {type: 'viewedPage'});
 

--- a/test/integration/load.test.ts
+++ b/test/integration/load.test.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
-import Cookies from 'js-cookie';
-import {CH} from './_helpers';
+import * as C from '../_helpers';
+import * as H from './_helpers';
 
 describe('When sdk.js is loaded', () => {
   it('should processes the queue', () => {
-    expect(Cookies.getJSON(CH).token).to.equal('ABC123_QUEUED');
+    expect(C.getCookieJSON(H.CH).token).to.equal('ABC123_QUEUED');
   });
 
   it('should not touch the window.Promise object', () => {

--- a/test/integration/utm.test.ts
+++ b/test/integration/utm.test.ts
@@ -1,11 +1,11 @@
 import {expect} from 'chai';
-import Cookies from 'js-cookie';
 import {UTMCookie} from '../../src/cookie';
+import * as C from '../_helpers';
 import * as H from './_helpers';
 
 describe('UTM automatic handling', () => {
   beforeEach(() => {
-    Cookies.remove(H.CH);
+    C.removeCookie(H.CH);
   });
 
   afterEach(() => {
@@ -18,7 +18,7 @@ describe('UTM automatic handling', () => {
 
     await H.setConfig();
 
-    expect(Cookies.getJSON(H.CH).ga).to.equal(undefined);
+    expect(C.getCookieJSON(H.CH).ga).to.equal(undefined);
   });
 
   it('should store utm_* vars in a separate _chutm cookie', async () => {
@@ -27,7 +27,7 @@ describe('UTM automatic handling', () => {
 
     await H.setConfig();
 
-    expect(Cookies.getJSON(H.UTM)).to.eql({
+    expect(C.getCookieJSON(H.UTM)).to.eql({
       utm_source: 'foo',
       utm_medium: 'bar',
       utm_term: 'baz',
@@ -49,7 +49,7 @@ describe('UTM automatic handling', () => {
       utm_campaign: 'foobarbaz'
     };
 
-    Cookies.set(H.UTM, {...Cookies.getJSON(H.UTM), ...utm});
+    C.setCookieJSON(H.UTM, {...C.getCookieJSON(H.UTM), ...utm});
 
     H._ch('event', {type: 'viewedPage'});
 

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -43,7 +43,7 @@ test('main() should execute `config` command', async () => {
 
   await H.wait();
 
-  expect(S.SET_HUB_COOKIE).toBeCalledWith(S.HUB_COOKIE, {expires: 365});
+  expect(S.SET_HUB_COOKIE).toBeCalledWith(S.HUB_COOKIE(), {expires: 365});
   expect(S.SET_UTM_COOKIE).toBeCalledWith(
     {utm_source: 'abcd', utm_medium: 'web'},
     {expires: 1 / 48}
@@ -82,7 +82,7 @@ test('main() should execute `event` command', async () => {
       customerId: undefined,
       bringBackProperties: {
         type: 'SESSION_ID',
-        value: S.HUB_COOKIE.sid,
+        value: S.HUB_COOKIE().sid,
         nodeId: H.NID
       }
     },
@@ -107,13 +107,13 @@ test('main() should execute `customer` command', async () => {
   expect(_HTTP.post).toBeCalledTimes(1); // <-- `shouldUpdate` is false because;
   expect(_HTTP.post).toBeCalledWith(
     `/workspaces/${H.WSID}/customers/${H.CID}/sessions`,
-    {value: S.HUB_COOKIE.sid},
+    {value: S.HUB_COOKIE().sid},
     H.TOKEN
   );
   expect(_HTTP.patch).not.toBeCalled();
   expect(S.SET_HUB_COOKIE).toBeCalledWith(
     {
-      ...S.HUB_COOKIE_CID,
+      ...S.HUB_COOKIE_CID(),
       hash: '44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a'
     },
     undefined
@@ -142,7 +142,7 @@ test('main() should execute command using configured Hub object name', async () 
 
   await H.wait();
 
-  expect(S.SET_HUB_COOKIE).toBeCalledWith(S.HUB_COOKIE, {expires: 365});
+  expect(S.SET_HUB_COOKIE).toBeCalledWith(S.HUB_COOKIE(), {expires: 365});
   expect(S.SET_UTM_COOKIE).toBeCalledWith(
     {utm_source: 'abcd', utm_medium: 'web'},
     {expires: 1 / 48}
@@ -172,7 +172,7 @@ test('main() should process operations queue', async () => {
 
   await H.wait();
 
-  expect(S.SET_HUB_COOKIE).toBeCalledWith(S.HUB_COOKIE, {expires: 365});
+  expect(S.SET_HUB_COOKIE).toBeCalledWith(S.HUB_COOKIE(), {expires: 365});
   expect(S.SET_UTM_COOKIE).toBeCalledWith(
     {utm_source: 'abcd', utm_medium: 'web'},
     {expires: 1 / 48}

--- a/test/services/cookie.ts
+++ b/test/services/cookie.ts
@@ -20,7 +20,9 @@ export const SET_UTM_COOKIE_KO: MockedSetUTM = jest.fn((_v, _o) =>
   left(new Error('Cookie "_chutm" cannot be set'))
 );
 
-export const HUB_COOKIE: HubCookie = {
+// beware of mutability...
+export const HUB_COOKIE = (): HubCookie => ({
+  target: 'ENTRY',
   token: H.TOKEN,
   workspaceId: H.WSID,
   nodeId: H.NID,
@@ -28,14 +30,17 @@ export const HUB_COOKIE: HubCookie = {
   context: 'WEB',
   contextInfo: {},
   sid: '5ed6cae6-e956-4da1-9b06-c971887ed756'
-};
+});
 
-export const HUB_COOKIE_CID: HubCookie = {...HUB_COOKIE, customerId: H.CID};
+export const HUB_COOKIE_CID = (): HubCookie => ({
+  ...HUB_COOKIE(),
+  customerId: H.CID
+});
 
-export const UTM_COOKIE: UTMCookie = {
+export const UTM_COOKIE = (): UTMCookie => ({
   utm_source: 'abcd',
   utm_medium: 'web'
-};
+});
 
 interface CookieProps {
   hub?: TaskEither<Error, HubCookie>;
@@ -43,8 +48,8 @@ interface CookieProps {
 }
 
 export const COOKIE = ({
-  hub = right(HUB_COOKIE),
-  utm = right(UTM_COOKIE)
+  hub = right(HUB_COOKIE()),
+  utm = right(UTM_COOKIE())
 }: CookieProps): Cookie => {
   let _hub = hub;
   let _utm = utm;
@@ -77,8 +82,8 @@ export const COOKIE = ({
 };
 
 export const COOKIE_SET_KO = ({
-  hub = right(HUB_COOKIE),
-  utm = right(UTM_COOKIE)
+  hub = right(HUB_COOKIE()),
+  utm = right(UTM_COOKIE())
 }: CookieProps): Cookie => ({
   getHub: f =>
     pipe(

--- a/test/target.spec.ts
+++ b/test/target.spec.ts
@@ -1,0 +1,60 @@
+import {left, right} from 'fp-ts/Either';
+import {getNodeAndToken} from '../src/target';
+import * as H from './_helpers';
+import {HUB_COOKIE} from './services';
+
+test('getNodeAndToken() should return `nodeId` and `token`', async () => {
+  const withTarget = await getNodeAndToken(HUB_COOKIE())();
+
+  expect(withTarget).toEqual(right({nodeId: H.NID, token: H.TOKEN}));
+
+  const noTarget = await getNodeAndToken({
+    ...HUB_COOKIE(),
+    target: undefined
+  })();
+
+  expect(noTarget).toEqual(right({nodeId: H.NID, token: H.TOKEN}));
+});
+
+test('getNodeAndToken() should return `aggregateNodeId` and `aggregateToken`', async () => {
+  const withAggregate = await getNodeAndToken({
+    ...HUB_COOKIE(),
+    target: 'AGGREGATE',
+    aggregateNodeId: 'aggrNid',
+    aggregateToken: 'AGGR_TOKEN'
+  })();
+
+  expect(withAggregate).toEqual(
+    right({nodeId: 'aggrNid', token: 'AGGR_TOKEN'})
+  );
+});
+
+test('getNodeAndToken() should fail if `aggregateNodeId` or `aggregateToken` are not defined', async () => {
+  const noNodeId = await getNodeAndToken({
+    ...HUB_COOKIE(),
+    target: 'AGGREGATE',
+    aggregateToken: 'AGGR_TOKEN'
+  })();
+
+  expect(noNodeId).toEqual(
+    left(
+      new Error(
+        '"aggregateNodeId" and "aggregateToken" must be set when "target" is "AGGREGATE"'
+      )
+    )
+  );
+
+  const noToken = await getNodeAndToken({
+    ...HUB_COOKIE(),
+    target: 'AGGREGATE',
+    aggregateNodeId: 'aggrNid'
+  })();
+
+  expect(noToken).toEqual(
+    left(
+      new Error(
+        '"aggregateNodeId" and "aggregateToken" must be set when "target" is "AGGREGATE"'
+      )
+    )
+  );
+});

--- a/test/target.spec.ts
+++ b/test/target.spec.ts
@@ -4,16 +4,9 @@ import * as H from './_helpers';
 import {HUB_COOKIE} from './services';
 
 test('getNodeAndToken() should return `nodeId` and `token`', async () => {
-  const withTarget = await getNodeAndToken(HUB_COOKIE())();
+  const result = await getNodeAndToken(HUB_COOKIE())();
 
-  expect(withTarget).toEqual(right({nodeId: H.NID, token: H.TOKEN}));
-
-  const noTarget = await getNodeAndToken({
-    ...HUB_COOKIE(),
-    target: undefined
-  })();
-
-  expect(noTarget).toEqual(right({nodeId: H.NID, token: H.TOKEN}));
+  expect(result).toEqual(right({nodeId: H.NID, token: H.TOKEN}));
 });
 
 test('getNodeAndToken() should return `aggregateNodeId` and `aggregateToken`', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,11 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["./src", "./test", "./webpack.config.ts", "./karma.conf.ts"]
+  "include": [
+    "./src",
+    "./test",
+    "./webpack.config.ts",
+    "./karma.conf.ts",
+    "./scripts"
+  ]
 }


### PR DESCRIPTION
This PR introduces aggregate nodes handling, maintaining backward compatibility with current API.

It was added a new optional `target` field to the SDK configuration object, with value `ENTRY | AGGREGATE` (default `ENTRY`) which it could be also set via a `target` query parameter (es. `?target=AGGREGATE`).

Moreover,  2 new optional fields were added: `aggregateNodeId` and `aggregateToken`, that will be used when `target=AGGREGATE` instead of `nodeId` and `token`.

For a better DX, it was added a `src/target.ts` module which exposes a `getNodeAndTarget()` utility: this retrieve returns (as an `Effect`) the node's id and token based on `target` and fails if `target=AGGREGATE` but either `aggregateNodeId` or `aggregateToken` are not defined.

Lastly, the customer's `create` and `update` operation were bypassed when `target` is `AGGREGATE`.

Resolves #80 